### PR TITLE
feat: Implement initial MCP chat and admin interface

### DIFF
--- a/mcp_chat_app/__init__.py
+++ b/mcp_chat_app/__init__.py
@@ -1,0 +1,1 @@
+# This file makes mcp_chat_app a Python package.

--- a/mcp_chat_app/app.py
+++ b/mcp_chat_app/app.py
@@ -1,0 +1,96 @@
+# This is the main Flask application file.
+
+from flask import Flask, render_template, request, jsonify, redirect, url_for
+
+# Import configurations. We will be modifying MCP_SERVERS.
+# Note: In a real multi-process/multi-threaded server, directly modifying
+# a list like this without thread safety mechanisms (locks) would be problematic.
+# For this educational example, it's fine.
+import config # This way we can access config.MCP_SERVERS
+
+# Create a Flask application instance
+app = Flask(__name__)
+# Flask will automatically look for 'templates' and 'static' folders
+# in the same directory as this file.
+
+# Load configurations if needed (e.g., app.config.from_object('config'))
+# For now, we directly use the imported config.MCP_SERVERS list.
+
+
+@app.route('/')
+def index():
+    """
+    Serves the main chat interface page.
+    Renders the index.html template.
+    """
+    return render_template('index.html')
+
+
+@app.route('/admin', methods=['GET', 'POST'])
+def admin():
+    """
+    Serves the admin configuration page.
+    Handles GET requests to display the page and server list.
+    Handles POST requests to add a new server configuration.
+    """
+    if request.method == 'POST':
+        # Get data from the form
+        server_name = request.form.get('server-name')
+        server_host = request.form.get('server-host')
+        server_port = request.form.get('server-port')
+
+        # Basic validation (in a real app, this would be more robust)
+        if server_name and server_host and server_port:
+            try:
+                # Ensure port is an integer
+                port = int(server_port)
+                new_server = {
+                    "name": server_name,
+                    "host": server_host,
+                    "port": port
+                }
+                config.MCP_SERVERS.append(new_server)
+                print(f"Added new server: {new_server}") # Server-side log
+                # Redirect to the admin page (GET request) to display the updated list
+                return redirect(url_for('admin'))
+            except ValueError:
+                # Handle error if port is not a valid number
+                # For simplicity, just re-render with an error message or ignore
+                print(f"Error: Port '{server_port}' is not a valid number.")
+                # Pass an error message to the template if desired
+                return render_template('admin.html', servers=config.MCP_SERVERS, error="Invalid port number.")
+        else:
+            # Handle error if any field is missing
+            print("Error: Missing form data for adding server.")
+            return render_template('admin.html', servers=config.MCP_SERVERS, error="All fields are required.")
+
+    # For GET requests, just render the page with the current list of servers
+    return render_template('admin.html', servers=config.MCP_SERVERS)
+
+
+@app.route('/send_message', methods=['POST'])
+def send_message_route():
+    """
+    API endpoint to receive messages from the chat interface.
+    Expects a JSON payload with a "message" field.
+    """
+    if not request.is_json:
+        return jsonify({"status": "error", "message": "Request must be JSON"}), 400
+
+    data = request.get_json()
+    message_text = data.get('message')
+
+    if message_text:
+        print(f"Received message via /send_message: {message_text}")
+        # Here, you would typically process the message:
+        # - Send it to the MCPClient
+        # - Broadcast it to other users via WebSockets, etc.
+        # For now, we just acknowledge receipt.
+        return jsonify({"status": "Message received", "message_echo": message_text}), 200
+    else:
+        return jsonify({"status": "error", "message": "No message content provided"}), 400
+
+
+# Main execution block to run the Flask development server
+if __name__ == '__main__':
+    app.run(debug=True, host='0.0.0.0', port=5000)

--- a/mcp_chat_app/config.py
+++ b/mcp_chat_app/config.py
@@ -1,0 +1,12 @@
+# This file is for storing configurations.
+# For example, MCP server details, API keys, etc.
+
+# Placeholder for MCP server configurations.
+# This list will be used to store and manage server details.
+# Each item in the list could be a dictionary, e.g.,
+# {"name": "Main Server", "host": "mcp.example.com", "port": 12345}
+MCP_SERVERS = []
+
+# Example of other configurations we might add later:
+# DEBUG = True
+# SECRET_KEY = 'your_secret_key_here'

--- a/mcp_chat_app/mcp_client.py
+++ b/mcp_chat_app/mcp_client.py
@@ -1,0 +1,134 @@
+# This file will contain the MCP client logic.
+# It will handle connections to the MCP server, sending/receiving messages, etc.
+
+class MCPClient:
+    """
+    A client for interacting with an MCP (Multi-Client Protocol) server.
+    This class will manage the connection, sending, and receiving of messages.
+    """
+
+    def __init__(self, host, port):
+        """
+        Initializes the MCPClient with server details.
+
+        Args:
+            host (str): The hostname or IP address of the MCP server.
+            port (int): The port number of the MCP server.
+        """
+        self.host = host
+        self.port = port
+        self.socket = None  # Placeholder for the actual socket object
+
+        print(f"MCPClient initialized for server at {self.host}:{self.port}")
+
+    def connect(self):
+        """
+        Establishes a connection to the MCP server.
+        (Placeholder: In a real implementation, this would involve socket connection)
+        """
+        print(f"Attempting to connect to MCP server at {self.host}:{self.port}...")
+        # TODO: Implement actual socket connection logic here
+        # Example:
+        # try:
+        #     self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        #     self.socket.connect((self.host, self.port))
+        #     print("Successfully connected to MCP server.")
+        # except Exception as e:
+        #     print(f"Failed to connect: {e}")
+        #     self.socket = None
+        print("Connection method called (placeholder).")
+
+    def disconnect(self):
+        """
+        Closes the connection to the MCP server.
+        (Placeholder: In a real implementation, this would close the socket)
+        """
+        print("Attempting to disconnect from MCP server...")
+        # TODO: Implement actual socket disconnection logic here
+        # Example:
+        # if self.socket:
+        #     self.socket.close()
+        #     self.socket = None
+        #     print("Successfully disconnected from MCP server.")
+        # else:
+        #     print("No active connection to disconnect.")
+        print("Disconnection method called (placeholder).")
+
+    def send_message(self, message_type, payload):
+        """
+        Sends a message to the MCP server.
+        (Placeholder: In a real implementation, this would format and send data over the socket)
+
+        Args:
+            message_type (str): The type of message being sent (e.g., 'CHAT', 'COMMAND').
+            payload (dict): The actual message content or command details.
+        """
+        print(f"Attempting to send message:")
+        print(f"  Type: {message_type}")
+        print(f"  Payload: {payload}")
+        # TODO: Implement actual message formatting and sending logic
+        # Example:
+        # if self.socket:
+        #     try:
+        #         formatted_message = f"{message_type}:{json.dumps(payload)}\n"
+        #         self.socket.sendall(formatted_message.encode('utf-8'))
+        #         print("Message sent successfully.")
+        #     except Exception as e:
+        #         print(f"Error sending message: {e}")
+        # else:
+        #     print("Cannot send message. No active connection.")
+        print("Send_message method called (placeholder).")
+
+    def receive_message(self):
+        """
+        Receives a message from the MCP server.
+        (Placeholder: In a real implementation, this would read and parse data from the socket)
+
+        Returns:
+            dict: A dictionary representing the received message, or None if no message.
+        """
+        print("Attempting to receive message from MCP server...")
+        # TODO: Implement actual message receiving and parsing logic
+        # Example:
+        # if self.socket:
+        #     try:
+        #         # This is a simplified example; real receiving logic would handle buffering,
+        #         # message delimitation (e.g., newlines), and potential blocking.
+        #         data = self.socket.recv(1024) # Buffer size
+        #         if data:
+        #             decoded_data = data.decode('utf-8').strip()
+        #             print(f"Received raw data: {decoded_data}")
+        #             # Assuming messages are in a simple format like "TYPE:JSON_PAYLOAD"
+        #             parts = decoded_data.split(':', 1)
+        #             if len(parts) == 2:
+        #                 message_type = parts[0]
+        #                 payload_json = parts[1]
+        #                 payload = json.loads(payload_json)
+        #                 return {"type": message_type, "payload": payload}
+        #             else:
+        #                 print(f"Could not parse message: {decoded_data}")
+        #                 return None
+        #         else:
+        #             print("No data received (connection might be closed).")
+        #             return None
+        #     except Exception as e:
+        #         print(f"Error receiving message: {e}")
+        #         return None
+        # else:
+        #     print("Cannot receive message. No active connection.")
+        #     return None
+        dummy_message = {"type": "STATUS", "payload": {"message": "Successfully received dummy message."}}
+        print(f"Receive_message method called (placeholder), returning: {dummy_message}")
+        return dummy_message
+
+if __name__ == '__main__':
+    # Example Usage (for testing purposes)
+    print("MCP Client Basic Test")
+    client = MCPClient(host="localhost", port=12345)
+    client.connect()
+    client.send_message(message_type="CHAT", payload={"user": "TestUser", "text": "Hello MCP Server!"})
+    received = client.receive_message()
+    if received:
+        print(f"Main test received: {received}")
+    client.disconnect()
+    print("MCP Client test finished.")

--- a/mcp_chat_app/static/script.js
+++ b/mcp_chat_app/static/script.js
@@ -1,0 +1,84 @@
+// This file will contain JavaScript for chat interface interactivity.
+
+console.log("MCP Chat script loaded.");
+
+// Get DOM elements
+const chatBox = document.getElementById('chat-box');
+const messageInput = document.getElementById('message-input');
+const sendButton = document.getElementById('send-button');
+
+function displayMessage(user, message) {
+    /**
+     * Displays a message in the chat box.
+     * @param {string} user - The user sending the message.
+     * @param {string} message - The message content.
+     */
+    const messageElement = document.createElement('p');
+    // Sanitize user and message if necessary, though for "You" it's controlled.
+    // For messages from server, ensure proper escaping/sanitization on server-side or client-side.
+    messageElement.textContent = `${user}: ${message}`;
+    chatBox.appendChild(messageElement);
+    // Scroll to the bottom of the chat box
+    chatBox.scrollTop = chatBox.scrollHeight;
+}
+
+async function sendMessage() {
+    /**
+     * Gets the message from the input field, displays it locally,
+     * sends it to the server, and clears the input.
+     */
+    const messageText = messageInput.value.trim();
+
+    if (messageText) {
+        // Display the user's own message immediately
+        displayMessage("You", messageText);
+
+        // Clear the input field
+        messageInput.value = '';
+
+        try {
+            const response = await fetch('/send_message', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({ message: messageText })
+            });
+
+            if (response.ok) {
+                const result = await response.json();
+                console.log('Message sent successfully:', result);
+                // Optionally, display a server confirmation or echo if needed
+                // For example, if the server pre-pends "[Broadcast]" or similar
+                // displayMessage("Server", result.message_echo); // Example
+            } else {
+                const errorResult = await response.json();
+                console.error('Error sending message:', response.status, errorResult);
+                displayMessage("System", `Error: Could not send message. ${errorResult.message || 'Server error'}`);
+            }
+        } catch (error) {
+            console.error('Network error or other issue sending message:', error);
+            displayMessage("System", "Error: Could not connect to the server to send message.");
+        }
+    }
+}
+
+// Event Listeners
+if (sendButton) {
+    sendButton.addEventListener('click', sendMessage);
+}
+
+if (messageInput) {
+    messageInput.addEventListener('keypress', function(event) {
+        // Check if the pressed key is Enter
+        if (event.key === 'Enter') {
+            sendMessage();
+        }
+    });
+}
+
+// Example initial message
+// displayMessage("System", "Welcome to MCP Chat! Type your message and press Send or Enter.");
+// This can be part of the initial HTML or loaded from server if needed.
+// For now, let's assume the chat starts empty or with server-loaded messages.
+console.log("Event listeners attached. Ready for chat.");

--- a/mcp_chat_app/static/style.css
+++ b/mcp_chat_app/static/style.css
@@ -1,0 +1,86 @@
+/*
+This file will contain basic styling for the application.
+*/
+
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    background-color: #f4f4f4;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+}
+
+#chat-container {
+    width: 400px;
+    height: 600px;
+    background-color: #fff;
+    border-radius: 8px;
+    box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+h1 {
+    text-align: center;
+    color: #333;
+    padding: 15px;
+    margin: 0;
+    border-bottom: 1px solid #eee;
+    font-size: 1.2em;
+}
+
+#chat-box {
+    flex-grow: 1;
+    border: 1px solid #ddd;
+    margin: 10px;
+    padding: 10px;
+    height: 450px; /* Fixed height */
+    overflow-y: scroll;
+    background-color: #f9f9f9;
+    border-radius: 4px;
+}
+
+#chat-box p {
+    margin: 5px 0;
+    padding: 8px;
+    background-color: #e9e9e9;
+    border-radius: 4px;
+    word-wrap: break-word;
+}
+
+#chat-box p:nth-child(odd) {
+    background-color: #f1f1f1;
+}
+
+#input-area {
+    display: flex;
+    padding: 10px;
+    border-top: 1px solid #eee;
+}
+
+#message-input {
+    flex-grow: 1;
+    padding: 10px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    margin-right: 8px;
+    font-size: 1em;
+}
+
+#send-button {
+    padding: 10px 15px;
+    background-color: #007bff;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 1em;
+}
+
+#send-button:hover {
+    background-color: #0056b3;
+}

--- a/mcp_chat_app/templates/admin.html
+++ b/mcp_chat_app/templates/admin.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MCP Admin Configuration</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+    <!-- Admin specific styles can be added later or in a separate CSS file -->
+    <style>
+        /* Basic styles for admin page elements */
+        body {
+            font-family: Arial, sans-serif;
+            margin: 20px;
+            background-color: #f9f9f9;
+            color: #333;
+        }
+        .container {
+            width: 80%;
+            margin: auto;
+            background-color: #fff;
+            padding: 20px;
+            border-radius: 8px;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        }
+        h1, h2 {
+            color: #333;
+            text-align: center;
+        }
+        .error-message {
+            color: red;
+            text-align: center;
+            margin-bottom: 15px;
+        }
+        form {
+            margin-bottom: 30px;
+            padding: 20px;
+            border: 1px solid #ddd;
+            border-radius: 5px;
+            background-color: #fefefe;
+        }
+        form label {
+            display: block;
+            margin-bottom: 8px;
+            font-weight: bold;
+        }
+        form input[type="text"],
+        form input[type="number"] {
+            width: calc(100% - 22px);
+            padding: 10px;
+            margin-bottom: 15px;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+        }
+        form button {
+            padding: 10px 20px;
+            background-color: #28a745;
+            color: white;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+        }
+        form button:hover {
+            background-color: #218838;
+        }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 20px;
+        }
+        table th, table td {
+            border: 1px solid #ddd;
+            padding: 10px;
+            text-align: left;
+        }
+        table th {
+            background-color: #f0f0f0;
+        }
+        table td button {
+            padding: 5px 10px;
+            margin-right: 5px;
+            cursor: pointer;
+            border: none;
+            border-radius: 3px;
+        }
+        .edit-btn {
+            background-color: #ffc107;
+            color: #333;
+        }
+        .delete-btn {
+            background-color: #dc3545;
+            color: white;
+        }
+        .no-servers {
+            text-align: center;
+            padding: 10px;
+            color: #777;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>MCP Admin Configuration</h1>
+
+        {% if error %}
+            <p class="error-message">{{ error }}</p>
+        {% endif %}
+
+        <section id="add-server-form">
+            <h2>Add New MCP Server</h2>
+            <form method="POST" action="{{ url_for('admin') }}">
+                <div>
+                    <label for="server-name">Server Name:</label>
+                    <input type="text" id="server-name" name="server-name" required>
+                </div>
+                <div>
+                    <label for="server-host">Server Host/IP:</label>
+                    <input type="text" id="server-host" name="server-host" required>
+                </div>
+                <div>
+                    <label for="server-port">Server Port:</label>
+                    <input type="number" id="server-port" name="server-port" required>
+                </div>
+                <button type="submit">Add Server</button>
+            </form>
+        </section>
+
+        <section id="existing-servers">
+            <h2>Existing Servers</h2>
+            {% if servers %}
+            <table>
+                <thead>
+                    <tr>
+                        <th>Server Name</th>
+                        <th>Host</th>
+                        <th>Port</th>
+                        <th>Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for server in servers %}
+                    <tr>
+                        <td>{{ server.name }}</td>
+                        <td>{{ server.host }}</td>
+                        <td>{{ server.port }}</td>
+                        <td>
+                            <button class="edit-btn">Edit</button>
+                            <button class="delete-btn">Delete</button>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+            {% else %}
+            <p class="no-servers">No servers configured yet.</p>
+            {% endif %}
+        </section>
+    </div>
+</body>
+</html>

--- a/mcp_chat_app/templates/index.html
+++ b/mcp_chat_app/templates/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MCP Chat</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+    <div id="chat-container">
+        <h1>MCP Chat Room</h1>
+        <div id="chat-box">
+            <!-- Chat messages will appear here -->
+        </div>
+        <div id="input-area">
+            <input type="text" id="message-input" placeholder="Type your message...">
+            <button id="send-button">Send</button>
+        </div>
+    </div>
+    <script src="{{ url_for('static', filename='script.js') }}"></script>
+</body>
+</html>

--- a/mcp_chat_app/test_app.py
+++ b/mcp_chat_app/test_app.py
@@ -1,0 +1,111 @@
+import unittest
+import json
+
+# Assuming test_app.py is in mcp_chat_app directory, or mcp_chat_app is in PYTHONPATH
+# For imports to work correctly when running `python -m unittest mcp_chat_app/test_app.py`
+# from the parent directory of mcp_chat_app, the imports should be:
+from .app import app # Relative import for app
+import config # Direct import for config, will be mcp_chat_app.config
+
+class TestApp(unittest.TestCase):
+
+    def setUp(self):
+        """Set up test client and clear MCP_SERVERS before each test."""
+        app.testing = True
+        self.client = app.test_client()
+        # Access MCP_SERVERS through the imported config module
+        config.MCP_SERVERS.clear()
+
+    def test_index_page(self):
+        """Test the index page loading and basic content."""
+        response = self.client.get('/')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"MCP Chat", response.data) # Check for title or key heading
+        self.assertIn(b"chat-box", response.data) # Check for a key element ID
+        self.assertIn(b"message-input", response.data)
+
+    def test_admin_page_get(self):
+        """Test the admin page loading and initial content."""
+        response = self.client.get('/admin')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Manage MCP Server Configurations", response.data)
+        self.assertIn(b"No servers configured yet.", response.data)
+
+    def test_add_server_to_admin_page(self):
+        """Test adding a server via POST and then viewing it on the admin page."""
+        # POST request to add a server
+        response_post = self.client.post('/admin', data={
+            'server-name': 'TestServer',
+            'server-host': 'localhost',
+            'server-port': '1234'
+        }, follow_redirects=False) # Do not follow redirects to check 302
+        self.assertEqual(response_post.status_code, 302) # Should redirect after POST
+        self.assertEqual(len(config.MCP_SERVERS), 1)
+        self.assertEqual(config.MCP_SERVERS[0]['name'], 'TestServer')
+        self.assertEqual(config.MCP_SERVERS[0]['host'], 'localhost')
+        self.assertEqual(config.MCP_SERVERS[0]['port'], 1234)
+
+        # GET request to see the server listed
+        response_get = self.client.get('/admin')
+        self.assertEqual(response_get.status_code, 200)
+        self.assertIn(b"TestServer", response_get.data)
+        self.assertIn(b"localhost", response_get.data)
+        self.assertIn(b"1234", response_get.data)
+        self.assertNotIn(b"No servers configured yet.", response_get.data)
+
+    def test_add_server_missing_fields(self):
+        """Test adding a server with missing fields."""
+        response = self.client.post('/admin', data={
+            'server-name': 'TestServerIncomplete',
+            # 'server-host' is missing
+            'server-port': '5678'
+        })
+        self.assertEqual(response.status_code, 200) # Should re-render admin page with error
+        self.assertIn(b"All fields are required.", response.data)
+        self.assertEqual(len(config.MCP_SERVERS), 0) # No server should be added
+
+    def test_add_server_invalid_port(self):
+        """Test adding a server with an invalid port number."""
+        response = self.client.post('/admin', data={
+            'server-name': 'TestServerInvalidPort',
+            'server-host': 'testhost',
+            'server-port': 'abc' # Invalid port
+        })
+        self.assertEqual(response.status_code, 200) # Re-renders with error
+        self.assertIn(b"Invalid port number.", response.data) # Check for specific error message
+        self.assertEqual(len(config.MCP_SERVERS), 0)
+
+    def test_send_message_endpoint(self):
+        """Test the /send_message endpoint with valid JSON data."""
+        response = self.client.post('/send_message',
+                                     data=json.dumps({'message': 'Hello Test'}),
+                                     content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+        json_response = json.loads(response.data.decode('utf-8'))
+        self.assertEqual(json_response['status'], 'Message received')
+        self.assertEqual(json_response['message_echo'], 'Hello Test')
+
+    def test_send_message_missing_message_key(self):
+        """Test /send_message with a missing 'message' key in JSON payload."""
+        response = self.client.post('/send_message',
+                                     data=json.dumps({'msg': 'Hello Test'}), # Incorrect key
+                                     content_type='application/json')
+        self.assertEqual(response.status_code, 400)
+        json_response = json.loads(response.data.decode('utf-8'))
+        self.assertEqual(json_response['status'], 'error')
+        self.assertIn('No message content provided', json_response['message'])
+
+    def test_send_message_not_json(self):
+        """Test /send_message with non-JSON data."""
+        response = self.client.post('/send_message',
+                                     data={'message': 'Hello Test'}) # Form data, not JSON
+        self.assertEqual(response.status_code, 400)
+        json_response = json.loads(response.data.decode('utf-8'))
+        self.assertEqual(json_response['status'], 'error')
+        self.assertIn('Request must be JSON', json_response['message'])
+
+if __name__ == '__main__':
+    # To run these tests:
+    # 1. Navigate to the directory containing the 'mcp_chat_app' package.
+    # 2. Run: python -m unittest mcp_chat_app/test_app.py
+    unittest.main()


### PR DESCRIPTION
This commit introduces a basic Flask application featuring:

- A simple chat interface (`index.html`) allowing you to send messages.
  - Frontend JavaScript handles message display and sending to the backend.
- An admin interface (`admin.html`) for managing MCP server configurations.
  - Server configurations (name, host, port) can be added via a form.
  - Configurations are stored in-memory (will reset on app restart).
  - The admin page displays the current list of configured servers.
- Backend logic (`app.py`):
  - Serves the chat and admin HTML pages.
  - Handles form submissions from the admin page to add servers.
  - Provides an endpoint (`/send_message`) for the chat interface to submit messages (currently prints to console).
- Basic MCP client structure (`mcp_client.py`) as a placeholder.
- Unit tests (`test_app.py`) for the Flask application routes and basic logic, ensuring:
  - Correct page rendering.
  - Server addition functionality and error handling in the admin section.
  - Message submission endpoint behavior.

The project structure includes templates, static files, and configuration management.